### PR TITLE
Avoid ARRAY_FILTER_USE_KEY for PHP 5.5 compatibility

### DIFF
--- a/Types/CurlOptions.php
+++ b/Types/CurlOptions.php
@@ -55,9 +55,10 @@ class CurlOptions extends \ArrayObject {
     public static function create(array $options) {
         Assertions::assertHashMap('options', $options);
 
-        $filteredOptions = array_filter($options, function($key) {
-            return preg_match('/^CURLOPT_/', $key);
-        }, ARRAY_FILTER_USE_KEY);
+        $filteredKeys = array_filter(array_keys($options), function ($key) {
+            return strpos($key, 'CURLOPT_') === 0;
+        });
+        $filteredOptions = array_intersect_key($options, array_flip($filteredKeys));
 
         $keys = array_map(function($key) {
             return constant($key);


### PR DESCRIPTION
Fixes #14

Also replaces `preg_match` with `strpos` [for performance reasons](http://stackoverflow.com/questions/6433492/preg-match-vs-strpos-for-match-finding).