### PR TITLE
fixed register annotations bug

### DIFF
--- a/MetaData.php
+++ b/MetaData.php
@@ -31,19 +31,6 @@ use Doctrine\Common\Persistence\ObjectManager;
 class MetaData {
 
     /**
-     * MetaDataProvider constructor
-     *
-     * @SuppressWarnings("PHPMD.StaticAccess")
-     */
-    public function __construct() {
-        AnnotationRegistry::registerFile(__DIR__ . DIRECTORY_SEPARATOR . 'Annotations' . DIRECTORY_SEPARATOR . 'Insert.php');
-        AnnotationRegistry::registerFile(__DIR__ . DIRECTORY_SEPARATOR . 'Annotations' . DIRECTORY_SEPARATOR . 'Update.php');
-        AnnotationRegistry::registerFile(__DIR__ . DIRECTORY_SEPARATOR . 'Annotations' . DIRECTORY_SEPARATOR . 'Select.php');
-        AnnotationRegistry::registerFile(__DIR__ . DIRECTORY_SEPARATOR . 'Annotations' . DIRECTORY_SEPARATOR . 'Fetch.php');
-        AnnotationRegistry::registerFile(__DIR__ . DIRECTORY_SEPARATOR . 'Annotations' . DIRECTORY_SEPARATOR . 'Delete.php');
-    }
-
-    /**
      * returns all namespaces of managed entities
      *
      * @return array

--- a/Tests/FunctionalTest.php
+++ b/Tests/FunctionalTest.php
@@ -45,19 +45,6 @@ class FunctionalTest extends WebTestCase {
      * {@inheritdoc}
      */
     public function setUp() {
-        AnnotationRegistry::registerFile(__DIR__ . '/../vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/Entity.php');
-        AnnotationRegistry::registerFile(__DIR__ . '/../vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/Table.php');
-        AnnotationRegistry::registerFile(__DIR__ . '/../vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/Column.php');
-        AnnotationRegistry::registerFile(__DIR__ . '/../vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/Id.php');
-        AnnotationRegistry::registerFile(__DIR__ . '/../vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/GeneratedValue.php');
-        AnnotationRegistry::registerFile(__DIR__ . '/../vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/OneToMany.php');
-        AnnotationRegistry::registerFile(__DIR__ . '/../vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/ManyToOne.php');
-        AnnotationRegistry::registerFile(__DIR__ . '/../Annotations/Insert.php');
-        AnnotationRegistry::registerFile(__DIR__ . '/../Annotations/Update.php');
-        AnnotationRegistry::registerFile(__DIR__ . '/../Annotations/Select.php');
-        AnnotationRegistry::registerFile(__DIR__ . '/../Annotations/Delete.php');
-        AnnotationRegistry::registerFile(__DIR__ . '/../Annotations/Fetch.php');
-
         static::bootKernel();
         $this->em = static::$kernel->getContainer()->get('doctrine.orm.default_entity_manager');
     }

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,14 @@
   "autoload": {
     "psr-0": {
       "Circle\\DoctrineRestDriver": ""
-    }
+    },
+    "files": [
+      "Annotations/Delete.php",
+      "Annotations/Fetch.php",
+      "Annotations/Insert.php",
+      "Annotations/Select.php",
+      "Annotations/Update.php"
+    ]
   },
   "target-dir": "Circle/DoctrineRestDriver",
   "extra": {


### PR DESCRIPTION
**Fixes** #32 Annotations registered too late

#### Proposed Changes
The registerFile function of Doctrine's AnnotationRegistry class just calls require_once $file. So to "add" an annotation correctly to Doctrine we just need to autoload the class by using composer's "file" section. This is what I've done.