### PR TITLE
Fixes bug with unintended whitespace from SQL string

### DIFF
--- a/Tests/Types/UpdateChangeSetTest.php
+++ b/Tests/Types/UpdateChangeSetTest.php
@@ -48,4 +48,22 @@ class UpdateChangeSetTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertSame($expected, UpdateChangeSet::create($tokens));
     }
+    
+    /**
+     * @test
+     * @group  unit
+     * @covers ::create
+     *
+     * @SuppressWarnings("PHPMD.StaticAccess")
+     */
+    public function createRemovesWhitespace() {
+        $parser   = new PHPSQLParser();
+        $tokens   = $parser->parse('UPDATE products set name = "testname", value = "testvalue" WHERE id = 1');
+        $expected = [
+            'name'  => 'testname',
+            'value' => 'testvalue',
+        ];
+
+        $this->assertSame($expected, UpdateChangeSet::create($tokens));
+    }
 }

--- a/Types/UpdateChangeSet.php
+++ b/Types/UpdateChangeSet.php
@@ -40,12 +40,12 @@ class UpdateChangeSet {
 
         $columns = array_map(function($token) {
             $segments = explode('=', $token['base_expr']);
-            return $segments[0];
+            return trim($segments[0]);
         }, $tokens['SET']);
 
         $values = array_map(function($token) {
             $segments = explode('=', $token['base_expr']);
-            return Value::create($segments[1]);
+            return trim(Value::create($segments[1]));
         }, $tokens['SET']);
 
         return array_combine($columns, $values);


### PR DESCRIPTION
**Fixes** #60 

#### Proposed Changes
* Trim whitespace from WHERE condition key and value pairs