### PR TITLE
#62 filtering columns suffixed by primary key

### DIFF
--- a/Tests/Factory/RequestFactoryTest.php
+++ b/Tests/Factory/RequestFactoryTest.php
@@ -67,7 +67,7 @@ class RequestFactoryTest extends \PHPUnit_Framework_TestCase {
      * @covers ::createOne
      */
     public function createOne() {
-        $query    = 'SELECT name FROM products WHERE id=1';
+        $query    = 'SELECT name FROM products t0 WHERE t0.id=1';
         $parser   = new PHPSQLParser();
         $factory  = new RequestFactory();
         $expected = new Request([

--- a/Tests/Transformers/MysqlToRequestTest.php
+++ b/Tests/Transformers/MysqlToRequestTest.php
@@ -102,7 +102,7 @@ class MysqlToRequestTest extends \PHPUnit_Framework_TestCase {
      * @covers ::<private>
      */
     public function selectOne() {
-        $query    = 'SELECT name FROM products WHERE id = 1';
+        $query    = 'SELECT name FROM products t0 WHERE t0.id = 1';
         $expected = new Request([
             'method'      => 'get',
             'url'         => $this->apiUrl . '/products/1',
@@ -120,7 +120,7 @@ class MysqlToRequestTest extends \PHPUnit_Framework_TestCase {
      * @covers ::<private>
      */
     public function selectOneBy() {
-        $query    = 'SELECT name FROM products WHERE id=1 AND name=myName';
+        $query    = 'SELECT name FROM products t0 WHERE t0.id=1 AND t0.name=myName';
         $expected = new Request([
             'method'      => 'get',
             'url'         => $this->apiUrl . '/products/1',
@@ -139,7 +139,7 @@ class MysqlToRequestTest extends \PHPUnit_Framework_TestCase {
      * @covers ::<private>
      */
     public function selectBy() {
-        $query    = 'SELECT name FROM products WHERE name=myName';
+        $query    = 'SELECT name FROM products t0 WHERE t0.name=myName';
         $expected = new Request([
             'method'      => 'get',
             'url'         => $this->apiUrl . '/products',

--- a/Tests/Types/HttpQueryTest.php
+++ b/Tests/Types/HttpQueryTest.php
@@ -40,7 +40,7 @@ class HttpQueryTest extends \PHPUnit_Framework_TestCase {
      */
     public function create() {
         $parser   = new PHPSQLParser();
-        $tokens   = $parser->parse('SELECT name FROM products WHERE id=1 AND value="testvalue" AND name="testname"');
+        $tokens   = $parser->parse('SELECT name FROM products t0 WHERE t0.id=1 AND t0.value="testvalue" AND t0.name="testname"');
         $expected = 'value=testvalue&name=testname';
 
         $this->assertSame($expected, HttpQuery::create($tokens));

--- a/Types/HttpQuery.php
+++ b/Types/HttpQuery.php
@@ -74,7 +74,7 @@ class HttpQuery {
         });
 
         // Remove primary key column before removing table alias and returning
-        return str_replace($tableAlias . '.', '', preg_replace('/' . $primaryKeyColumn . '=[\w\d]*&*/', '', $sqlWhereString));
+        return str_replace($tableAlias . '.', '', preg_replace('/' . preg_quote($primaryKeyColumn) . '=[\w\d]*&*/', '', $sqlWhereString));
     }
 
     /**


### PR DESCRIPTION
**Fixes** #62 

#### Proposed Changes
* Filter primary keys with greater accuracy to prevent changes to other keys

This fix works by leaving the table alias prefix on the column names. This allows the regex to find the only the primary key. Columns then have the prefix removed once the primary key has been successfully removed.