### PR TITLE
Change default value of CURLOPT_SSLVERSION

### DIFF
--- a/Tests/Types/CurlOptionsTest.php
+++ b/Tests/Types/CurlOptionsTest.php
@@ -56,7 +56,7 @@ class CurlOptionsTest extends \PHPUnit_Framework_TestCase {
             CURLOPT_TIMEOUT        => 25,
             CURLOPT_CONNECTTIMEOUT => 25,
             CURLOPT_CRLF           => true,
-            CURLOPT_SSLVERSION     => 3,
+            CURLOPT_SSLVERSION     => 0,
             CURLOPT_FOLLOWLOCATION => true,
         ];
     }

--- a/Types/CurlOptions.php
+++ b/Types/CurlOptions.php
@@ -37,7 +37,7 @@ class CurlOptions extends \ArrayObject {
         CURLOPT_TIMEOUT        => 25,
         CURLOPT_CONNECTTIMEOUT => 25,
         CURLOPT_CRLF           => true,
-        CURLOPT_SSLVERSION     => 3,
+        CURLOPT_SSLVERSION     => 0,
         CURLOPT_FOLLOWLOCATION => true,
     ];
 


### PR DESCRIPTION
Hi,
according to the official PHP documentation using *CURLOPT_SSLVERSION* with values of 2 or 3 is discouraged.
(http://php.net/manual/en/function.curl-setopt.php)
>Note:
>Your best bet is to not set this and let it use the default. Setting it to 2 or 3 is very dangerous given the known vulnerabilities in SSLv2 and SSLv3.

**Fixes** #
Bad default value
#### Proposed Changes
* Change the default value of curl's SSL_VERSION from *3* to *0*