### PR TITLE
Update composer.json to use version 2.0.2 of the ci/restclientbundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,6 @@
     "doctrine/dbal": "2.*",
     "greenlion/php-sql-parser": "^4.0",
     "doctrine/orm": "2.*",
-    "ci/restclientbundle": "^1.0"
+    "ci/restclientbundle": "^2.0.2"
   }
 }


### PR DESCRIPTION
Fixes the error:
The reserved indicator "%" cannot start a plain scalar; you need to quote the scalar at line 6 (near "class: %circle.restclient.class%")