### PR TITLE
Correctly typed values for "empty()" values [0 | "" | false | null | ...]

### DIFF
--- a/Tests/Annotations/DeleteTest.php
+++ b/Tests/Annotations/DeleteTest.php
@@ -28,7 +28,7 @@ use Circle\DoctrineRestDriver\Annotations\Delete;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Annotations\Delete
  */
-class DeleteTest extends \PHPUnit_Framework_TestCase {
+class DeleteTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Annotations/FetchTest.php
+++ b/Tests/Annotations/FetchTest.php
@@ -28,7 +28,7 @@ use Circle\DoctrineRestDriver\Annotations\Fetch;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Annotations\Fetch
  */
-class FetchTest extends \PHPUnit_Framework_TestCase {
+class FetchTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Annotations/InsertTest.php
+++ b/Tests/Annotations/InsertTest.php
@@ -28,7 +28,7 @@ use Circle\DoctrineRestDriver\Annotations\Insert;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Annotations\Insert
  */
-class InsertTest extends \PHPUnit_Framework_TestCase {
+class InsertTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Annotations/ReaderTest.php
+++ b/Tests/Annotations/ReaderTest.php
@@ -30,7 +30,7 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Annotations\Reader
  */
-class ReaderTest extends \PHPUnit_Framework_TestCase {
+class ReaderTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * {@inheritdoc}

--- a/Tests/Annotations/RoutingTableTest.php
+++ b/Tests/Annotations/RoutingTableTest.php
@@ -30,7 +30,7 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Annotations\RoutingTable
  */
-class RoutingTableTest extends \PHPUnit_Framework_TestCase {
+class RoutingTableTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * {@inheritdoc}

--- a/Tests/Annotations/RoutingTest.php
+++ b/Tests/Annotations/RoutingTest.php
@@ -33,7 +33,7 @@ use Circle\DoctrineRestDriver\Annotations\Routing;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Annotations\Routing
  */
-class RoutingTest extends \PHPUnit_Framework_TestCase {
+class RoutingTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * {@inheritdoc}

--- a/Tests/Annotations/SelectTest.php
+++ b/Tests/Annotations/SelectTest.php
@@ -28,7 +28,7 @@ use Circle\DoctrineRestDriver\Annotations\Select;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Annotations\Select
  */
-class SelectTest extends \PHPUnit_Framework_TestCase {
+class SelectTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Annotations/UpdateTest.php
+++ b/Tests/Annotations/UpdateTest.php
@@ -28,7 +28,7 @@ use Circle\DoctrineRestDriver\Annotations\Update;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Annotations\Update
  */
-class UpdateTest extends \PHPUnit_Framework_TestCase {
+class UpdateTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/DriverTest.php
+++ b/Tests/DriverTest.php
@@ -28,7 +28,7 @@ use Circle\DoctrineRestDriver\Driver;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Driver
  */
-class DriverTest extends \PHPUnit_Framework_TestCase {
+class DriverTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @var Driver

--- a/Tests/Enum/HttpMethodsTest.php
+++ b/Tests/Enum/HttpMethodsTest.php
@@ -29,7 +29,7 @@ use Circle\DoctrineRestDriver\Enums\SqlOperations;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Enums\HttpMethods
  */
-class HttpMethodsTest extends \PHPUnit_Framework_TestCase {
+class HttpMethodsTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Exceptions/ExceptionsTest.php
+++ b/Tests/Exceptions/ExceptionsTest.php
@@ -31,7 +31,7 @@ use Circle\DoctrineRestDriver\Types\Request;
  *
  * @SuppressWarnings("PHPMD.StaticAccess")
  */
-class ExceptionsTest extends \PHPUnit_Framework_TestCase {
+class ExceptionsTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Factory/RequestFactoryTest.php
+++ b/Tests/Factory/RequestFactoryTest.php
@@ -30,7 +30,7 @@ use PHPSQLParser\PHPSQLParser;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Factory\RequestFactory
  */
-class RequestFactoryTest extends \PHPUnit_Framework_TestCase {
+class RequestFactoryTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @var array

--- a/Tests/Factory/RestClientFactoryTest.php
+++ b/Tests/Factory/RestClientFactoryTest.php
@@ -28,7 +28,7 @@ use Circle\DoctrineRestDriver\Factory\RestClientFactory;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Factory\RestClientFactory
  */
-class RestClientFactoryTest extends \PHPUnit_Framework_TestCase {
+class RestClientFactoryTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Formatters/JsonTest.php
+++ b/Tests/Formatters/JsonTest.php
@@ -28,7 +28,7 @@ use Circle\DoctrineRestDriver\Formatters\Json;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Formatters\Json
  */
-class JsonTest extends \PHPUnit_Framework_TestCase {
+class JsonTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/RestClientTest.php
+++ b/Tests/RestClientTest.php
@@ -31,7 +31,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\RestClient
  */
-class RestClientTest extends \PHPUnit_Framework_TestCase {
+class RestClientTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @var RestClient

--- a/Tests/Security/HttpAuthenticationTest.php
+++ b/Tests/Security/HttpAuthenticationTest.php
@@ -30,7 +30,7 @@ use Circle\DoctrineRestDriver\Types\Request;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Security\HttpAuthentication
  */
-class HttpAuthenticationTest extends \PHPUnit_Framework_TestCase {
+class HttpAuthenticationTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @var HttpAuthentication

--- a/Tests/Security/NoAuthenticationTest.php
+++ b/Tests/Security/NoAuthenticationTest.php
@@ -30,7 +30,7 @@ use Circle\DoctrineRestDriver\Types\Request;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Security\NoAuthentication
  */
-class NoAuthenticationTest extends \PHPUnit_Framework_TestCase {
+class NoAuthenticationTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @var NoAuthentication

--- a/Tests/StatementTest.php
+++ b/Tests/StatementTest.php
@@ -28,7 +28,7 @@ use Circle\DoctrineRestDriver\Statement;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Statement
  */
-class StatementTest extends \PHPUnit_Framework_TestCase {
+class StatementTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @var Statement

--- a/Tests/Transformers/MysqlToRequestTest.php
+++ b/Tests/Transformers/MysqlToRequestTest.php
@@ -32,7 +32,7 @@ use Circle\DoctrineRestDriver\Types\Request;
  * @coversDefaultClass Circle\DoctrineRestDriver\Transformers\MysqlToRequest
  * @SuppressWarnings("PHPMD.TooManyPublicMethods")
  */
-class MysqlToRequestTest extends \PHPUnit_Framework_TestCase {
+class MysqlToRequestTest extends \PHPUnit\Framework\TestCase {
 
     /**
      *

--- a/Tests/Types/AnnotationTest.php
+++ b/Tests/Types/AnnotationTest.php
@@ -31,7 +31,7 @@ use PHPSQLParser\PHPSQLParser;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\Annotation
  */
-class AnnotationTest extends \PHPUnit_Framework_TestCase {
+class AnnotationTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/AuthenticationTest.php
+++ b/Tests/Types/AuthenticationTest.php
@@ -28,7 +28,7 @@ use Circle\DoctrineRestDriver\Types\Authentication;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\Authentication
  */
-class AuthenticationTest extends \PHPUnit_Framework_TestCase {
+class AuthenticationTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/CurlOptionsTest.php
+++ b/Tests/Types/CurlOptionsTest.php
@@ -28,7 +28,7 @@ use Circle\DoctrineRestDriver\Types\CurlOptions;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\CurlOptions
  */
-class CurlOptionsTest extends \PHPUnit_Framework_TestCase {
+class CurlOptionsTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @var array

--- a/Tests/Types/FormatTest.php
+++ b/Tests/Types/FormatTest.php
@@ -28,7 +28,7 @@ use Circle\DoctrineRestDriver\Types\Format;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\Format
  */
-class FormatTest extends \PHPUnit_Framework_TestCase {
+class FormatTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/HashMapEntryTest.php
+++ b/Tests/Types/HashMapEntryTest.php
@@ -28,7 +28,7 @@ use Circle\DoctrineRestDriver\Types\HashMapEntry;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\HashMapEntry
  */
-class HashMapEntryTest extends \PHPUnit_Framework_TestCase {
+class HashMapEntryTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/HashMapTest.php
+++ b/Tests/Types/HashMapTest.php
@@ -28,7 +28,7 @@ use Circle\DoctrineRestDriver\Types\HashMap;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\HashMap
  */
-class HashMapTest extends \PHPUnit_Framework_TestCase {
+class HashMapTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/HttpHeaderTest.php
+++ b/Tests/Types/HttpHeaderTest.php
@@ -28,7 +28,7 @@ use PHPSQLParser\PHPSQLParser;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\HttpHeader
  */
-class HttpHeaderTest extends \PHPUnit_Framework_TestCase {
+class HttpHeaderTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @var array

--- a/Tests/Types/HttpMethodTest.php
+++ b/Tests/Types/HttpMethodTest.php
@@ -29,7 +29,7 @@ use Circle\DoctrineRestDriver\Types\HttpMethod;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\HttpMethod
  */
-class HttpMethodTest extends \PHPUnit_Framework_TestCase {
+class HttpMethodTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/HttpQueryTest.php
+++ b/Tests/Types/HttpQueryTest.php
@@ -29,7 +29,7 @@ use PHPSQLParser\PHPSQLParser;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\HttpQuery
  */
-class HttpQueryTest extends \PHPUnit_Framework_TestCase {
+class HttpQueryTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/IdentifierTest.php
+++ b/Tests/Types/IdentifierTest.php
@@ -29,7 +29,7 @@ use PHPSQLParser\PHPSQLParser;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\Identifier
  */
-class IdentifierTest extends \PHPUnit_Framework_TestCase {
+class IdentifierTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/InsertChangeSetTest.php
+++ b/Tests/Types/InsertChangeSetTest.php
@@ -29,7 +29,7 @@ use PHPSQLParser\PHPSQLParser;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\InsertChangeSet
  */
-class InsertChangeSetTest extends \PHPUnit_Framework_TestCase {
+class InsertChangeSetTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/MaybeIntTest.php
+++ b/Tests/Types/MaybeIntTest.php
@@ -28,7 +28,7 @@ use Circle\DoctrineRestDriver\Types\MaybeInt;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\MaybeInt
  */
-class MaybeIntTest extends \PHPUnit_Framework_TestCase {
+class MaybeIntTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/MaybeListTest.php
+++ b/Tests/Types/MaybeListTest.php
@@ -28,7 +28,7 @@ use Circle\DoctrineRestDriver\Types\MaybeList;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\MaybeList
  */
-class MaybeListTest extends \PHPUnit_Framework_TestCase {
+class MaybeListTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/MaybeStringTest.php
+++ b/Tests/Types/MaybeStringTest.php
@@ -28,7 +28,7 @@ use Circle\DoctrineRestDriver\Types\MaybeString;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\MaybeString
  */
-class MaybeStringTest extends \PHPUnit_Framework_TestCase {
+class MaybeStringTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/NotNilTest.php
+++ b/Tests/Types/NotNilTest.php
@@ -28,7 +28,7 @@ use Circle\DoctrineRestDriver\Types\NotNil;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\NotNil
  */
-class NotNilTest extends \PHPUnit_Framework_TestCase {
+class NotNilTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/OrderingHeadersTest.php
+++ b/Tests/Types/OrderingHeadersTest.php
@@ -28,7 +28,7 @@ use PHPSQLParser\PHPSQLParser;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\OrderingHeaders
  */
-class OrderingHeadersTest extends \PHPUnit_Framework_TestCase {
+class OrderingHeadersTest extends \PHPUnit\Framework\TestCase {
 
 
     /**

--- a/Tests/Types/PaginationHeadersTest.php
+++ b/Tests/Types/PaginationHeadersTest.php
@@ -28,7 +28,7 @@ use PHPSQLParser\PHPSQLParser;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\PaginationHeaders
  */
-class PaginationHeadersTest extends \PHPUnit_Framework_TestCase {
+class PaginationHeadersTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @var array

--- a/Tests/Types/PayloadTest.php
+++ b/Tests/Types/PayloadTest.php
@@ -29,7 +29,7 @@ use PHPSQLParser\PHPSQLParser;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\Payload
  */
-class PayloadTest extends \PHPUnit_Framework_TestCase {
+class PayloadTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/RequestTest.php
+++ b/Tests/Types/RequestTest.php
@@ -29,7 +29,7 @@ use Circle\DoctrineRestDriver\Types\RestClientOptions;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\Request
  */
-class RequestTest extends \PHPUnit_Framework_TestCase {
+class RequestTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/ResultTest.php
+++ b/Tests/Types/ResultTest.php
@@ -29,7 +29,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\Result
  */
-class ResultTest extends \PHPUnit_Framework_TestCase {
+class ResultTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/SelectAllResultTest.php
+++ b/Tests/Types/SelectAllResultTest.php
@@ -30,7 +30,7 @@ use PHPSQLParser\PHPSQLParser;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\SelectAllResult
  */
-class SelectAllResultTest extends \PHPUnit_Framework_TestCase {
+class SelectAllResultTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/SelectResultTest.php
+++ b/Tests/Types/SelectResultTest.php
@@ -29,7 +29,7 @@ use PHPSQLParser\PHPSQLParser;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\SelectResult
  */
-class SelectResultTest extends \PHPUnit_Framework_TestCase {
+class SelectResultTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/SelectSingleResultTest.php
+++ b/Tests/Types/SelectSingleResultTest.php
@@ -29,7 +29,7 @@ use PHPSQLParser\PHPSQLParser;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\SelectSingleResult
  */
-class SelectSingleResultTest extends \PHPUnit_Framework_TestCase {
+class SelectSingleResultTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/SqlOperationTest.php
+++ b/Tests/Types/SqlOperationTest.php
@@ -30,7 +30,7 @@ use PHPSQLParser\PHPSQLParser;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\SqlOperation
  */
-class SqlOperationTest extends \PHPUnit_Framework_TestCase {
+class SqlOperationTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/SqlQueryTest.php
+++ b/Tests/Types/SqlQueryTest.php
@@ -54,6 +54,24 @@ class SqlQueryTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test
+     * @group unit
+     * @covers ::getStringRepresentation
+     *
+     * @throws \Circle\DoctrineRestDriver\Validation\Exceptions\InvalidTypeException
+     * @SuppressWarnings("PHPMD.StaticAccess")
+     */
+    public function getStringRepresentation() {
+        $this->assertSame('true', SqlQuery::getStringRepresentation(true));
+        $this->assertSame('false', SqlQuery::getStringRepresentation(false));
+        $this->assertSame('null', SqlQuery::getStringRepresentation(null));
+
+        $this->assertNotSame('null', SqlQuery::getStringRepresentation(false));
+        $this->assertNotSame('null', SqlQuery::getStringRepresentation(true));
+        $this->assertNotSame('null', SqlQuery::getStringRepresentation(0));
+    }
+
+    /**
+     * @test
      * @group  unit
      * @covers ::quoteUrl
      *

--- a/Tests/Types/SqlQueryTest.php
+++ b/Tests/Types/SqlQueryTest.php
@@ -38,12 +38,17 @@ class SqlQueryTest extends \PHPUnit\Framework\TestCase {
      * @SuppressWarnings("PHPMD.StaticAccess")
      */
     public function setParams() {
-        $query  = 'SELECT name FROM products WHERE id=? AND name=?';
+        $query  = 'SELECT name FROM products WHERE id=? AND name=? AND parent = ? AND active = ? AND foo = ? AND cost = ? OR cost = ?';
         $params = [
             1,
-            'myName'
+            'myName',
+            null,
+            true,
+            false,
+            0.0,
+            '2.5',
         ];
-        $expected = 'SELECT name FROM products WHERE id=1 AND name=myName';
+        $expected = 'SELECT name FROM products WHERE id=1 AND name=\'myName\' AND parent = null AND active = true AND foo = false AND cost = 0 OR cost = 2.5';
         $this->assertSame($expected, SqlQuery::setParams($query, $params));
     }
 

--- a/Tests/Types/SqlQueryTest.php
+++ b/Tests/Types/SqlQueryTest.php
@@ -28,7 +28,7 @@ use Circle\DoctrineRestDriver\Types\SqlQuery;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\SqlQuery
  */
-class SqlQueryTest extends \PHPUnit_Framework_TestCase {
+class SqlQueryTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/StatusCodeTest.php
+++ b/Tests/Types/StatusCodeTest.php
@@ -29,7 +29,7 @@ use Circle\DoctrineRestDriver\Types\StatusCode;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\StatusCode
  */
-class StatusCodeTest extends \PHPUnit_Framework_TestCase {
+class StatusCodeTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/StrTest.php
+++ b/Tests/Types/StrTest.php
@@ -28,7 +28,7 @@ use Circle\DoctrineRestDriver\Types\Str;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\Str
  */
-class StrTest extends \PHPUnit_Framework_TestCase {
+class StrTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/TableTest.php
+++ b/Tests/Types/TableTest.php
@@ -38,7 +38,7 @@ use PHPSQLParser\PHPSQLParser;
  *
  * @SuppressWarnings("PHPMD.TooManyPublicMethods")
  */
-class TableTest extends \PHPUnit_Framework_TestCase {
+class TableTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/UpdateChangeSetTest.php
+++ b/Tests/Types/UpdateChangeSetTest.php
@@ -29,7 +29,7 @@ use PHPSQLParser\PHPSQLParser;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\UpdateChangeSet
  */
-class UpdateChangeSetTest extends \PHPUnit_Framework_TestCase {
+class UpdateChangeSetTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/UrlTest.php
+++ b/Tests/Types/UrlTest.php
@@ -29,7 +29,7 @@ use PHPSQLParser\PHPSQLParser;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\Url
  */
-class UrlTest extends \PHPUnit_Framework_TestCase {
+class UrlTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Types/ValueTest.php
+++ b/Tests/Types/ValueTest.php
@@ -42,5 +42,11 @@ class ValueTest extends \PHPUnit\Framework\TestCase {
         $this->assertSame(1.01, Value::create('1.01'));
         $this->assertSame('hello', Value::create('hello'));
         $this->assertSame('hello', Value::create('"hello"'));
+
+        $this->assertSame(true, Value::create('true'));
+        $this->assertSame(false, Value::create('false'));
+        $this->assertSame(null, Value::create('null'));
+
+        $this->assertNotSame(null, Value::create('false'));
     }
 }

--- a/Tests/Types/ValueTest.php
+++ b/Tests/Types/ValueTest.php
@@ -28,7 +28,7 @@ use Circle\DoctrineRestDriver\Types\Value;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Types\Value
  */
-class ValueTest extends \PHPUnit_Framework_TestCase {
+class ValueTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Validation/AssertionsTest.php
+++ b/Tests/Validation/AssertionsTest.php
@@ -28,7 +28,7 @@ use Circle\DoctrineRestDriver\Validation\Assertions;
  *
  * @coversDefaultClass Circle\DoctrineRestDriver\Validation\Assertions
  */
-class AssertionsTest extends \PHPUnit_Framework_TestCase {
+class AssertionsTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Validation/Exceptions/InvalidTypeExceptionTest.php
+++ b/Tests/Validation/Exceptions/InvalidTypeExceptionTest.php
@@ -30,7 +30,7 @@ use Circle\DoctrineRestDriver\Validation\Exceptions\InvalidTypeException;
  *
  * @SuppressWarnings("PHPMD.StaticAccess")
  */
-class InvalidTypeExceptionTest extends \PHPUnit_Framework_TestCase {
+class InvalidTypeExceptionTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Tests/Validation/Exceptions/NotNilExceptionTest.php
+++ b/Tests/Validation/Exceptions/NotNilExceptionTest.php
@@ -30,7 +30,7 @@ use Circle\DoctrineRestDriver\Validation\Exceptions\NotNilException;
  *
  * @SuppressWarnings("PHPMD.StaticAccess")
  */
-class NotNilExceptionTest extends \PHPUnit_Framework_TestCase {
+class NotNilExceptionTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @test

--- a/Types/SqlQuery.php
+++ b/Types/SqlQuery.php
@@ -44,8 +44,34 @@ class SqlQuery {
         Str::assert($query, 'query');
 
         return array_reduce($params, function($query, $param) {
+            $param = self::getStringRepresentation($param);
+
             return strpos($query, '?') ? substr_replace($query, $param, strpos($query, '?'), strlen('?')) : $query;
         }, $query);
+    }
+
+    /**
+     * @param $param
+     *
+     * @return string
+     *
+     * @throws \Circle\DoctrineRestDriver\Validation\Exceptions\InvalidTypeException
+     */
+    public static function getStringRepresentation($param)
+    {
+        if (is_int($param) || is_float($param) || is_numeric($param)) {
+            return (string)$param;
+        } elseif (is_string($param)) {
+            return '\'' . $param . '\'';
+        } elseif ($param === true) {
+            return 'true';
+        } elseif ($param === false) {
+            return 'false';
+        } elseif ($param === null) {
+            return 'null';
+        } else {
+            Exceptions::InvalidTypeException('string | int | float | bool | null', '$param', $param);
+        }
     }
 
     /**

--- a/Types/SqlQuery.php
+++ b/Types/SqlQuery.php
@@ -59,20 +59,12 @@ class SqlQuery {
      */
     public static function getStringRepresentation($param)
     {
-        if (is_int($param) || is_float($param))
-        {
-            return $param;
-        } elseif (is_numeric($param)) {
-            return (float)$param;
-        } elseif (is_string($param)) {
-            return '\'' . $param . '\'';
-        } elseif ($param === true) {
-            return 'true';
-        } elseif ($param === false) {
-            return 'false';
-        } elseif ($param === null) {
-            return 'null';
-        }
+        if (is_int($param) || is_float($param)) return $param;
+        if (is_numeric($param))                 return (float)$param;
+        if (is_string($param))                  return '\'' . $param . '\'';
+        if ($param === true)                    return 'true';
+        if ($param === false)                   return 'false';
+        if ($param === null)                    return 'null';
 
         throw new \Circle\DoctrineRestDriver\Validation\Exceptions\InvalidTypeException('string | int | float | bool | null', '$param', $param);
     }

--- a/Types/SqlQuery.php
+++ b/Types/SqlQuery.php
@@ -53,14 +53,17 @@ class SqlQuery {
     /**
      * @param $param
      *
-     * @return string
+     * @return string|int|float|boolean|null
      *
      * @throws \Circle\DoctrineRestDriver\Validation\Exceptions\InvalidTypeException
      */
     public static function getStringRepresentation($param)
     {
-        if (is_int($param) || is_float($param) || is_numeric($param)) {
-            return (string)$param;
+        if (is_int($param) || is_float($param))
+        {
+            return $param;
+        } elseif (is_numeric($param)) {
+            return (float)$param;
         } elseif (is_string($param)) {
             return '\'' . $param . '\'';
         } elseif ($param === true) {

--- a/Types/SqlQuery.php
+++ b/Types/SqlQuery.php
@@ -72,9 +72,9 @@ class SqlQuery {
             return 'false';
         } elseif ($param === null) {
             return 'null';
-        } else {
-            Exceptions::InvalidTypeException('string | int | float | bool | null', '$param', $param);
         }
+
+        throw new \Circle\DoctrineRestDriver\Validation\Exceptions\InvalidTypeException('string | int | float | bool | null', '$param', $param);
     }
 
     /**

--- a/Types/UpdateChangeSet.php
+++ b/Types/UpdateChangeSet.php
@@ -45,7 +45,7 @@ class UpdateChangeSet {
 
         $values = array_map(function($token) {
             $segments = explode('=', $token['base_expr']);
-            return trim(Value::create($segments[1]));
+            return Value::create(trim($segments[1]));
         }, $tokens['SET']);
 
         return array_combine($columns, $values);

--- a/Types/Value.php
+++ b/Types/Value.php
@@ -41,14 +41,9 @@ class Value {
     public static function create($value) {
         Str::assert($value, 'value');
 
-        switch ($value) {
-            case 'true':
-                return true;
-            case 'false':
-                return false;
-            case 'null':
-                return null;
-        }
+        if($value === 'true')  return true;
+        if($value === 'false') return false;
+        if($value === 'null')  return null;
 
         $unquoted = preg_replace('/\"|\\\'|\`$/', '', preg_replace('/^\"|\\\'|\`/', '', $value));
         if (!is_numeric($unquoted))                   return $unquoted;

--- a/Types/Value.php
+++ b/Types/Value.php
@@ -40,7 +40,15 @@ class Value {
      */
     public static function create($value) {
         Str::assert($value, 'value');
-        if (empty($value)) return null;
+
+        switch ($value) {
+            case 'true':
+                return true;
+            case 'false':
+                return false;
+            case 'null':
+                return null;
+        }
 
         $unquoted = preg_replace('/\"|\\\'|\`$/', '', preg_replace('/^\"|\\\'|\`/', '', $value));
         if (!is_numeric($unquoted))                   return $unquoted;


### PR DESCRIPTION
**Fixes** #76 

#### Proposed Changes
* add the correct types to the json when the value seems empty to php. Now you can safely set false as your active flag and can use PHP 7.1 scalar type hints on the receiving side
* extended tests to cover the new type conversions
    * SqlQueryTest
    * ValueTest
* fixed a small issue where the update statement and insert statement would have different types. trim order changed
* Fixed `extends` of TestCases to work with the default installation via make. Got ClassNotFound Exceptions during testing