### PR TITLE
Fix String IDs enclosed in Quotes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,13 @@ test:
 	php -S 127.0.0.1:3000 -t Tests/app 2>1 & ./vendor/phpunit/phpunit/phpunit -c phpunit.xml --coverage-html $(LOGDIR)/coverage
 	ps -eaf | awk '/ph[p] -S/{ print $$2 }' | xargs kill
 	rm 1
+unit:
+	php -S 127.0.0.1:3000 -t Tests/app 2>1 & ./vendor/phpunit/phpunit/phpunit -c phpunit.xml --coverage-html $(LOGDIR)/coverage
+	ps -eaf | awk '/ph[p] -S/{ print $$2 }' | xargs kill
+	rm 1
+clean:
+	ps -eaf | awk '/ph[p] -S/{ print $$2 }' | xargs kill
+	rm 1
 docs:
 
 install:

--- a/Tests/Factory/ResponseExceptionFactoryTest.php
+++ b/Tests/Factory/ResponseExceptionFactoryTest.php
@@ -28,7 +28,7 @@ use Doctrine\DBAL\Exception as DBALException;
  * 
  * @author Rob Treacy <robert.treacy@thesalegroup.co.uk>
  */
-class ResponseExceptionFactoryTest extends \PHPUnit_Framework_TestCase {
+class ResponseExceptionFactoryTest extends \PHPUnit\Framework\TestCase {
     private $responseExceptionFactory;
     
     public function setUp() {
@@ -42,8 +42,8 @@ class ResponseExceptionFactoryTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider createDbalExceptionProvider
      */
     public function createDbalException(Response $response, $expectedExceptionClass) {
-        $return = $this->responseExceptionFactory->createDbalException($response, $this->createMock(DriverExceptionInterface::class));
-        $this->assertInstanceOf($expectedExceptionClass, $return);
+        $return = $this->responseExceptionFactory->createDbalException($response, $this->createMock($expectedExceptionClass));
+        $this->assertInstanceOf(DriverExceptionInterface::class, $return);
     }
     
     /**

--- a/Tests/Types/IdentifierTest.php
+++ b/Tests/Types/IdentifierTest.php
@@ -52,6 +52,48 @@ class IdentifierTest extends \PHPUnit\Framework\TestCase {
      *
      * @SuppressWarnings("PHPMD.StaticAccess")
      */
+    public function createWithStringId() {
+        $parser = new PHPSQLParser();
+        $tokens = $parser->parse('SELECT name FROM products WHERE id="test"');
+
+        $this->assertSame('test', Identifier::create($tokens));
+    }
+
+    /**
+     * @test
+     * @group  unit
+     * @covers ::create
+     *
+     * @SuppressWarnings("PHPMD.StaticAccess")
+     */
+    public function createWithStringIdSingleQuotes() {
+        $parser = new PHPSQLParser();
+        $tokens = $parser->parse('SELECT name FROM products WHERE id=\'test\'');
+
+        $this->assertSame('test', Identifier::create($tokens));
+    }
+
+    /**
+     * @test
+     * @group  unit
+     * @covers ::create
+     *
+     * @SuppressWarnings("PHPMD.StaticAccess")
+     */
+    public function createWithStringIdNoQuotes() {
+        $parser = new PHPSQLParser();
+        $tokens = $parser->parse('SELECT name FROM products WHERE id=test');
+
+        $this->assertSame('test', Identifier::create($tokens));
+    }
+
+    /**
+     * @test
+     * @group  unit
+     * @covers ::create
+     *
+     * @SuppressWarnings("PHPMD.StaticAccess")
+     */
     public function createWithEmptyId() {
         $parser = new PHPSQLParser();
         $tokens = $parser->parse('SELECT name FROM products WHERE name="test"');

--- a/Types/HttpQuery.php
+++ b/Types/HttpQuery.php
@@ -70,7 +70,7 @@ class HttpQuery {
 
         // Get WHERE conditions as string including table alias and primary key column if present
         $sqlWhereString = array_reduce($tokens['WHERE'], function($query, $token) use ($tableAlias) {
-            return $query . str_replace('"', '', str_replace('OR', '|', str_replace('AND', '&', $token['base_expr'])));
+            return $query . str_replace(['"', '\''], '', str_replace('OR', '|', str_replace('AND', '&', $token['base_expr'])));
         });
 
         // Remove primary key column before removing table alias and returning

--- a/Types/Identifier.php
+++ b/Types/Identifier.php
@@ -19,7 +19,6 @@
 namespace Circle\DoctrineRestDriver\Types;
 
 use Circle\DoctrineRestDriver\MetaData;
-use Circle\DoctrineRestDriver\Validation\Assertions;
 
 /**
  * Extracts id information from a sql token array
@@ -45,10 +44,10 @@ class Identifier {
         $idAlias = self::alias($tokens);
 
         return array_reduce($tokens['WHERE'], function($carry, $token) use ($tokens, $idAlias) {
-            if (!is_int($carry)) return $carry;
+            if ($carry !== null) return (string)Value::create($carry);
             if ($token['expr_type'] === 'colref' && $token['base_expr'] === $idAlias) return $tokens['WHERE'][$carry+2]['base_expr'];
             if (!isset($tokens[$carry+1])) return '';
-        }, 0);
+        }, null);
     }
 
     /**

--- a/Types/Value.php
+++ b/Types/Value.php
@@ -40,7 +40,7 @@ class Value {
      */
     public static function create($value) {
         Str::assert($value, 'value');
-      
+
         if($value === 'true')  return true;
         if($value === 'false') return false;
         if($value === 'null')  return null;


### PR DESCRIPTION
**Fixes** #79 

#### Proposed Changes
* Added new tests for string ids in sql queries
* Fixed the Identifier Generation now checking for `null` not `!is_int()` so the numeric identifier can be of the correct type
* Fixed Fatal Error in ResponseExceptionFactoryTest and extend statement