### PR TITLE
String Values had no quotes

### DIFF
--- a/Tests/Types/ValueTest.php
+++ b/Tests/Types/ValueTest.php
@@ -42,6 +42,8 @@ class ValueTest extends \PHPUnit\Framework\TestCase {
         $this->assertSame(1.01, Value::create('1.01'));
         $this->assertSame('hello', Value::create('hello'));
         $this->assertSame('hello', Value::create('"hello"'));
+        $this->assertSame('hello', Value::create('\'hello\''));
+        $this->assertSame('hello', Value::create('`hello`'));
         $this->assertSame('\'hello"', Value::create('\'hello"'));
 
         $encoded = '{"test":true}';

--- a/Tests/Types/ValueTest.php
+++ b/Tests/Types/ValueTest.php
@@ -43,6 +43,11 @@ class ValueTest extends \PHPUnit\Framework\TestCase {
         $this->assertSame('hello', Value::create('hello'));
         $this->assertSame('hello', Value::create('"hello"'));
 
+        $encoded = '{"test":true}';
+
+        $this->assertSame($encoded, Value::create("\"{$encoded}\""));
+        $this->assertSame($encoded, Value::create("{$encoded}"));
+
         $this->assertSame(true, Value::create('true'));
         $this->assertSame(false, Value::create('false'));
         $this->assertSame(null, Value::create('null'));

--- a/Tests/Types/ValueTest.php
+++ b/Tests/Types/ValueTest.php
@@ -42,6 +42,7 @@ class ValueTest extends \PHPUnit\Framework\TestCase {
         $this->assertSame(1.01, Value::create('1.01'));
         $this->assertSame('hello', Value::create('hello'));
         $this->assertSame('hello', Value::create('"hello"'));
+        $this->assertSame('\'hello"', Value::create('\'hello"'));
 
         $encoded = '{"test":true}';
 

--- a/Types/Value.php
+++ b/Types/Value.php
@@ -45,7 +45,7 @@ class Value {
         if($value === 'false') return false;
         if($value === 'null')  return null;
 
-        $unquoted = preg_replace('/\"|\\\'|\`$/', '', preg_replace('/^\"|\\\'|\`/', '', $value));
+        $unquoted = preg_replace('/\"$|\\\'$|\`$/', '', preg_replace('/^\"|^\\\'|^\`/', '', $value));
         if (!is_numeric($unquoted))                   return $unquoted;
         if ((string) intval($unquoted) === $unquoted) return intval($unquoted);
 

--- a/Types/Value.php
+++ b/Types/Value.php
@@ -45,7 +45,7 @@ class Value {
         if($value === 'false') return false;
         if($value === 'null')  return null;
 
-        $unquoted = preg_replace('/^\"(.*)\"$|^\\\'(.*)\\\'$|^\`(.*)\`$/', '$1', $value);
+        $unquoted = preg_replace('/^(?|\"(.*)\"|\\\'(.*)\\\'|\`(.*)\`)$/', '$1', $value);
         if (!is_numeric($unquoted))                   return $unquoted;
         if ((string) intval($unquoted) === $unquoted) return intval($unquoted);
 

--- a/Types/Value.php
+++ b/Types/Value.php
@@ -45,7 +45,7 @@ class Value {
         if($value === 'false') return false;
         if($value === 'null')  return null;
 
-        $unquoted = preg_replace('/\"$|\\\'$|\`$/', '', preg_replace('/^\"|^\\\'|^\`/', '', $value));
+        $unquoted = preg_replace('/^\"(.*)\"$|^\\\'(.*)\\\'$|^\`(.*)\`$/', '$1', $value);
         if (!is_numeric($unquoted))                   return $unquoted;
         if ((string) intval($unquoted) === $unquoted) return intval($unquoted);
 


### PR DESCRIPTION
**Fixes**

When transmitting e.g. Json Values they didn't have quotes inside and therefor where invalid.

The Regex that should've checked for end of string and start of string was not limited to these string positions.

#### Proposed Changes
* Only Quotes from the start and the end are replaced now
* Only a quote pair get's replaced. Before `"foo` would result in `foo`, now it is not modified, only `"foo"` is striped.
* Wrote more test cases for such values (a short json string and a mixed quoted string), related tests are passing.